### PR TITLE
Update React ref syntax to avoid Invariant Violation

### DIFF
--- a/src/webcam/index.js
+++ b/src/webcam/index.js
@@ -90,7 +90,7 @@ class Webcam extends Component {
     navigator.getUserMedia(
       constraints,
       (stream) => {
-        const video = this.refs.video;
+        const video = this._video;
 
         if (window.URL) {
           video.src = window.URL.createObjectURL(stream);
@@ -138,7 +138,7 @@ class Webcam extends Component {
       const canvas = this._getCanvas();
       const ctx = canvas.getContext("2d");
 
-      ctx.drawImage(this.refs.video, 0, 0, width, height);
+      ctx.drawImage(this._video, 0, 0, width, height);
 
       return canvas.toDataURL(captureFormat);
     }
@@ -155,7 +155,7 @@ class Webcam extends Component {
       <video
         width={width}
         height={height}
-        ref="video"
+        ref={(component) => this._video = component}
         autoPlay
       />
     )


### PR DESCRIPTION
The library was throwing an Invariant Violation Error (https://facebook.github.io/react/warnings/refs-must-have-owner.html). Changing the ref syntax from String to Function seems to have fixed the issue.

The full error:

```
Uncaught Error: Invariant Violation: addComponentAsRefTo(...): Only a ReactOwner can have refs. You might be adding a ref to a component that was not created inside a component's `render` method, or you have multiple copies of React loaded (details: https://fb.me/react-refs-must-have-owner).
```
